### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,10 @@ on: # events that trigger our pipeline: push on any branch and release creation
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   lint:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/carlosmazzei/pyscenario/security/code-scanning/3](https://github.com/carlosmazzei/pyscenario/security/code-scanning/3)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should define the least privileges required for each job. For example:
- The `lint` and `test` jobs primarily read repository contents, so they can be limited to `contents: read`.
- The `build-n-publish` job requires write access to publish packages, so it can include `contents: read` and `packages: write`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions per job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
