### PR TITLE
feat: add support for tracking physical cover relay states

### DIFF
--- a/src/pyscenario/config_schema.py
+++ b/src/pyscenario/config_schema.py
@@ -41,6 +41,9 @@ shades_schema = Schema(
         Required("address1"): Coerce(str),
         Required("address2"): Coerce(str),
         Required("address3"): Coerce(str),
+        Optional("module"): Coerce(int),
+        Optional("open_channel"): Coerce(int),
+        Optional("close_channel"): Coerce(int),
     }
 )
 

--- a/src/pyscenario/manager.py
+++ b/src/pyscenario/manager.py
@@ -160,7 +160,16 @@ class Cover(Device):
     """
 
     def __init__(
-        self, unique_id: str, name: str, zone: str, up: str, stop: str, down: str
+        self,
+        unique_id: str,
+        name: str,
+        zone: str,
+        up: str,
+        stop: str,
+        down: str,
+        module: int | None = None,
+        open_channel: int | None = None,
+        close_channel: int | None = None,
     ) -> None:
         """
         Initialize a Cover object.
@@ -172,6 +181,9 @@ class Cover(Device):
             up (str): Address for the up command.
             stop (str): Address for the stop command.
             down (str): Address for the down command.
+            module (int | None): Opcional module address of the physical relay.
+            open_channel (int | None): Opcional channel of the opening physical relay.
+            close_channel (int | None): Opcional channel of the closing physical relay.
         """
         super().__init__()
         self.unique_id = str(f"{unique_id}_{zone}").lower().replace(" ", "_")
@@ -180,6 +192,9 @@ class Cover(Device):
         self.up = up
         self.stop = stop
         self.down = down
+        self.module = module
+        self.open_channel = open_channel
+        self.close_channel = close_channel
         self.is_closed = False
 
 
@@ -265,15 +280,21 @@ class DeviceManager:
                     up=str(covers_data["address1"]),
                     stop=str(covers_data["address2"]),
                     down=str(covers_data["address3"]),
+                    module=covers_data.get("module"),
+                    open_channel=covers_data.get("open_channel"),
+                    close_channel=covers_data.get("close_channel"),
                 )
                 covers.append(cover)
                 logger.debug(
-                    "[device_id=%s type=cover zone=%s up=%s stop=%s down=%s] parsed",
+                    "[device_id=%s type=cover zone=%s up=%s stop=%s down=%s module=%s open_channel=%s close_channel=%s] parsed",
                     cover.unique_id,
                     cover.zone,
                     cover.up,
                     cover.stop,
                     cover.down,
+                    cover.module,
+                    cover.open_channel,
+                    cover.close_channel,
                 )
 
             logger.info(
@@ -375,9 +396,50 @@ class DeviceManager:
                             "[device_id=%s] no subscriber registered, skipping callback",
                             light.unique_id,
                         )
+
+        # Match covers/shades physical relay zone state changes
+        for cover in self.covers:
+            if cover.module == module_number:
+                if cover.open_channel == channel:
+                    matched = True
+                    if cover.callback_ is not None:
+                        kwargs = {"open_relay": state}
+                        logger.debug(
+                            "[device_id=%s name=%s module=%02d channel=%02d open_relay=%s] cover physical relay state updated",
+                            cover.unique_id,
+                            cover.name,
+                            module_number,
+                            channel,
+                            state,
+                        )
+                        cover.callback_(**kwargs)
+                    else:
+                        logger.debug(
+                            "[device_id=%s] no subscriber registered, skipping callback",
+                            cover.unique_id,
+                        )
+                elif cover.close_channel == channel:
+                    matched = True
+                    if cover.callback_ is not None:
+                        kwargs = {"close_relay": state}
+                        logger.debug(
+                            "[device_id=%s name=%s module=%02d channel=%02d close_relay=%s] cover physical relay state updated",
+                            cover.unique_id,
+                            cover.name,
+                            module_number,
+                            channel,
+                            state,
+                        )
+                        cover.callback_(**kwargs)
+                    else:
+                        logger.debug(
+                            "[device_id=%s] no subscriber registered, skipping callback",
+                            cover.unique_id,
+                        )
+
         if not matched:
             logger.warning(
-                "[module=%02d channel=%02d state=%s] zone state change has no matching light",
+                "[module=%02d channel=%02d state=%s] zone state change has no matching light/cover",
                 module_number,
                 channel,
                 state,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -213,6 +213,46 @@ async def test_device_manager_async_handle_scene_state_change(
     callback.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_device_manager_cover_physical_relays(monkeypatch):
+    """Test handling physical cover relay zone state change in DeviceManager."""
+    cover = Cover(
+        unique_id="2_bedroom",
+        name="Shade 1",
+        zone="Bedroom",
+        up="1234",
+        stop="5678",
+        down="9012",
+        module=1,
+        open_channel=7,
+        close_channel=8,
+    )
+    manager = DeviceManager(
+        lights=[],
+        covers=[cover],
+        zones={"2": "Bedroom"},
+    )
+
+    callback = mock.Mock()
+    monkeypatch.setattr(cover, "callback_", callback)
+
+    # Test open relay ON (intensity = 100)
+    await manager.async_handle_zone_state_change(1, 7, 100)
+    callback.assert_called_with(open_relay=100)
+
+    # Test open relay OFF (intensity = 0)
+    await manager.async_handle_zone_state_change(1, 7, 0)
+    callback.assert_called_with(open_relay=0)
+
+    # Test close relay ON (intensity = 100)
+    await manager.async_handle_zone_state_change(1, 8, 100)
+    callback.assert_called_with(close_relay=100)
+
+    # Test close relay OFF (intensity = 0)
+    await manager.async_handle_zone_state_change(1, 8, 0)
+    callback.assert_called_with(close_relay=0)
+
+
 def test_device_manager_notify_subscriber(monkeypatch, mock_device_manager_config):
     """Test notifying subscribers in DeviceManager."""
     manager = DeviceManager.from_config("device_config.yaml")

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ parallel = True
 
 [testenv]
 deps =
-    pytest
-    pytest-cov
-    pytest-asyncio
-    pytest-timeout
+    pytest>=8.2.2,<10.0.0
+    pytest-cov>=5,<8
+    pytest-asyncio>=0.23.7,<1.4.0
+    pytest-timeout>=2.3.1,<3.0.0
 commands =
     pytest -s -v --cov=pyscenario --timeout=10 {posargs} tests
 


### PR DESCRIPTION
This PR adds support for mapping and tracking physical cover relay state changes (e.g. open/close relays mapped via `module`, `open_channel` and `close_channel`) to allow integrations (such as Home Assistant cover platform) to calculate accurate cover positions based on relay active times. Unit tests included.